### PR TITLE
~/.fab/PKGPATH/fab.bin

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -47,21 +47,10 @@ import (
 //   - The go compiler is invoked to produce an executable,
 //     which is renamed into place as binfile.
 func Compile(ctx context.Context, pkgdir, binfile string) error {
-	if filepath.IsAbs(pkgdir) {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return errors.Wrap(err, "getting current directory")
-		}
-		rel, err := filepath.Rel(cwd, pkgdir)
-		if err != nil {
-			return errors.Wrapf(err, "getting relative path to %s", pkgdir)
-		}
-		if strings.HasPrefix(rel, "../") {
-			return fmt.Errorf("pkgdir must be in or under current directory")
-		}
-		pkgdir = rel
+	pkgpath, err := toRelPath(pkgdir)
+	if err != nil {
+		return errors.Wrapf(err, "getting relative path for %s", pkgdir)
 	}
-	pkgpath := "./" + filepath.Clean(pkgdir)
 
 	config := &packages.Config{
 		Mode:    packages.NeedName | packages.NeedFiles | packages.NeedTypes | packages.NeedDeps,

--- a/compile_test.go
+++ b/compile_test.go
@@ -13,15 +13,111 @@ import (
 )
 
 func TestCompile(t *testing.T) {
-	tbCompile(t)
+	tbCompile(t, func(tmpdir, pkgdir string) {
+		var (
+			fabdir  = filepath.Join(tmpdir, "fab")
+			rulesgo = filepath.Join(pkgdir, "rules.go")
+		)
+
+		m := Main{
+			Pkgdir:  pkgdir,
+			Fabdir:  fabdir,
+			Verbose: testing.Verbose(),
+		}
+
+		ctx := context.Background()
+
+		driver, err := m.getDriver(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		info, err := os.Stat(driver)
+		if err != nil {
+			t.Fatal(err)
+		}
+		modtime := info.ModTime()
+
+		cmd := exec.CommandContext(ctx, driver, "noop")
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err = cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+
+		// If the driver is (wrongly) recompiled here,
+		// this sleep forces the modtime to be different
+		// (on systems where file-modtime granularity
+		// is no better than one second).
+		time.Sleep(time.Second)
+
+		driver, err = m.getDriver(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err = os.Stat(driver)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !modtime.Equal(info.ModTime()) {
+			t.Error("driver got rebuilt unexpectedly")
+		}
+
+		f, err := os.OpenFile(rulesgo, os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		fmt.Fprintln(f, "// comment")
+		if err = f.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		driver, err = m.getDriver(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err = os.Stat(driver)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if modtime.Equal(info.ModTime()) {
+			t.Error("driver did not get rebuilt but should have")
+		}
+
+		cmd = exec.CommandContext(ctx, driver, "noop")
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err = cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func BenchmarkCompile(b *testing.B) {
-	tbCompile(b)
+	tbCompile(b, func(_, pkgdir string) {
+		tmpfile, err := os.CreateTemp("", "fab")
+		if err != nil {
+			b.Fatal(err)
+		}
+		tmpname := tmpfile.Name()
+		defer os.Remove(tmpname)
+		if err = tmpfile.Close(); err != nil {
+			b.Fatal(err)
+		}
+
+		ctx := context.Background()
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			if err = Compile(ctx, pkgdir, tmpname); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 // Test or benchmark the compiler.
-func tbCompile(tb testing.TB) {
+func tbCompile(tb testing.TB, f func(tmpdir, pkgdir string)) {
 	tmpdir, err := os.MkdirTemp("", "fab")
 	if err != nil {
 		tb.Fatal(err)
@@ -29,8 +125,6 @@ func tbCompile(tb testing.TB) {
 	defer os.RemoveAll(tmpdir)
 
 	compiledir := filepath.Join(tmpdir, "compile")
-
-	ctx := context.Background()
 
 	if err = copy.Copy("_testdata/compile", compiledir); err != nil {
 		tb.Fatal(err)
@@ -47,108 +141,5 @@ func tbCompile(tb testing.TB) {
 
 	pkgdir := filepath.Join(compiledir, "pkg")
 
-	if b, ok := tb.(*testing.B); ok {
-		tmpfile, err := os.CreateTemp("", "fab")
-		if err != nil {
-			b.Fatal(err)
-		}
-		tmpname := tmpfile.Name()
-		defer os.Remove(tmpname)
-		if err = tmpfile.Close(); err != nil {
-			b.Fatal(err)
-		}
-
-		b.ResetTimer()
-
-		for i := 0; i < b.N; i++ {
-			if err = Compile(ctx, pkgdir, tmpname); err != nil {
-				b.Fatal(err)
-			}
-		}
-
-		return
-	}
-
-	if t, ok := tb.(*testing.T); ok {
-		var (
-			fabdir  = filepath.Join(tmpdir, "fab")
-			rulesgo = filepath.Join(pkgdir, "rules.go")
-		)
-
-		m := Main{
-			Pkgdir:  pkgdir,
-			Fabdir:  fabdir,
-			Verbose: testing.Verbose(),
-		}
-
-		driver1, err := m.getDriver(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		info, err := os.Stat(driver1)
-		if err != nil {
-			t.Fatal(err)
-		}
-		modtime := info.ModTime()
-
-		cmd := exec.CommandContext(ctx, driver1, "noop")
-		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
-		if err = cmd.Run(); err != nil {
-			t.Fatal(err)
-		}
-
-		// If the driver is (wrongly) recompiled here,
-		// this sleep forces driver2's modtime to be different from driver1's
-		// (on systems where file-modtime granularity is no better than one second).
-		time.Sleep(time.Second)
-
-		driver2, err := m.getDriver(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if driver1 != driver2 {
-			t.Errorf("unexpected new driver %s (vs %s)", driver2, driver1)
-		} else {
-			info, err = os.Stat(driver2)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !modtime.Equal(info.ModTime()) {
-				t.Errorf("driver %s got rebuilt unexpectedly", driver2)
-			}
-		}
-
-		cmd = exec.CommandContext(ctx, driver2, "noop")
-		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
-		if err = cmd.Run(); err != nil {
-			t.Fatal(err)
-		}
-
-		f, err := os.OpenFile(rulesgo, os.O_WRONLY|os.O_APPEND, 0644)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer f.Close()
-		fmt.Fprintln(f, "// comment")
-		if err = f.Close(); err != nil {
-			t.Fatal(err)
-		}
-
-		driver3, err := m.getDriver(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if driver1 == driver3 {
-			t.Error("driver did not get rebuilt but should have")
-		}
-
-		cmd = exec.CommandContext(ctx, driver3, "noop")
-		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
-		if err = cmd.Run(); err != nil {
-			t.Fatal(err)
-		}
-
-		return
-	}
+	f(tmpdir, pkgdir)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/benbjohnson/clock v1.3.0
-	github.com/bobg/go-generics v1.1.0
+	github.com/bobg/go-generics v1.2.0
 	github.com/fatih/camelcase v1.0.0
 	github.com/gibson042/canonicaljson-go v1.0.3
 	github.com/mattn/go-shellwords v1.0.12

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bobg/go-generics v1.1.0 h1:kXt1VBk2Z9kRhrNQhOlRlTqbDlchayT457cIqnTB8VA=
 github.com/bobg/go-generics v1.1.0/go.mod h1:2c0zc1xzeC52OM0sKB4uUbb/OD90QFpJNIn984TKFBQ=
+github.com/bobg/go-generics v1.2.0 h1:Qq0dUEY1uaCrbz1JJ15eLXD1cnilQAhu1FeKk1YoMHQ=
+github.com/bobg/go-generics v1.2.0/go.mod h1:2c0zc1xzeC52OM0sKB4uUbb/OD90QFpJNIn984TKFBQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -108,6 +108,18 @@ func (m Main) getDriver(ctx context.Context) (string, error) {
 			fmt.Println("Forcing recompilation of driver")
 		}
 	} else {
+		_, err = os.Stat(driver)
+		if errors.Is(err, fs.ErrNotExist) {
+			compile = true
+			if m.Verbose {
+				fmt.Println("Compiling driver")
+			}
+		} else if err != nil {
+			return "", errors.Wrapf(err, "statting %s", driver)
+		}
+	}
+
+	if !compile {
 		oldhash, err = os.ReadFile(hashfile)
 		if errors.Is(err, fs.ErrNotExist) {
 			compile = true

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+	"golang.org/x/tools/go/packages"
 )
 
 // Main is the structure whose Run methods implements the main logic of the fab command.
@@ -43,6 +45,23 @@ type Main struct {
 // Typically this will include one or more target names,
 // in which case the driver will execute the associated rules as defined by the code in m.Pkgdir.
 func (m Main) Run(ctx context.Context) error {
+	pkgdir := m.Pkgdir
+	if filepath.IsAbs(pkgdir) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return errors.Wrap(err, "getting current directory")
+		}
+		rel, err := filepath.Rel(cwd, pkgdir)
+		if err != nil {
+			return errors.Wrapf(err, "getting relative path to %s", pkgdir)
+		}
+		if strings.HasPrefix(rel, "../") {
+			return fmt.Errorf("package dir %s is not in or under current directory", pkgdir)
+		}
+		pkgdir = rel
+	}
+	pkgpath := "./" + filepath.Clean(pkgdir)
+
 	args := []string{"-fab", m.Fabdir}
 	if m.Verbose {
 		args = append(args, "-v")
@@ -52,76 +71,119 @@ func (m Main) Run(ctx context.Context) error {
 	}
 	args = append(args, m.Args...)
 
-	driver, err := m.getDriver(ctx)
+	config := &packages.Config{
+		Mode:    packages.NeedName | packages.NeedFiles,
+		Context: ctx,
+	}
+	pkgs, err := packages.Load(config, pkgpath)
 	if err != nil {
-		return errors.Wrap(err, "ensuring driver binary is up to date")
+		return errors.Wrapf(err, "loading %s", pkgpath)
+	}
+	if len(pkgs) != 1 {
+		return fmt.Errorf("found %d packages in %s, want 1", len(pkgs), pkgpath)
+	}
+	pkg := pkgs[0]
+	if len(pkg.Errors) > 0 {
+		err = nil
+		for _, e := range pkg.Errors {
+			err = multierr.Append(err, e)
+		}
+		return errors.Wrapf(err, "loading package %s", pkg.Name)
+	}
+
+	// fset := token.NewFileSet()
+	// pkgmap, err := parser.ParseDir(fset, m.Pkgdir, nil, 0)
+	// if err != nil {
+	// 	return errors.Wrapf(err, "parsing directory %s", m.Pkgdir)
+	// }
+
+	// if len(pkgmap) != 1 {
+	// 	return fmt.Errorf("found %d Go packages in %s (want 1)", len(pkgmap), m.Pkgdir)
+	// }
+
+	// var (
+	// 	pkgname string
+	// 	astpkg  *ast.Package
+	// )
+	// for n, p := range pkgmap {
+	// 	pkgname, astpkg = n, p
+	// 	break
+	// }
+
+	// conf := types.Config{
+	// 	Importer: importer.Default(),
+	// }
+	// pkg, err := conf.Check(pkgname, fset, maps.Values(astpkg.Files), nil)
+	// if err != nil {
+	// 	return errors.Wrapf(err, "type-checking package %s in directory %s", pkgname, m.Pkgdir)
+	// }
+
+	driverdir := filepath.Join(m.Fabdir, pkg.PkgPath)
+	if err = os.MkdirAll(driverdir, 0755); err != nil {
+		return errors.Wrapf(err, "ensuring directory %s/%s exists", m.Fabdir, pkg.PkgPath)
+	}
+
+	var (
+		hashfile = filepath.Join(driverdir, "hash")
+		driver   = filepath.Join(driverdir, "fab.bin")
+		compile  bool
+		oldhash  []byte
+	)
+
+	if m.Force {
+		compile = true
+		if m.Verbose {
+			fmt.Println("Forcing recompilation of driver")
+		}
+	} else {
+		oldhash, err = os.ReadFile(hashfile)
+		if errors.Is(err, fs.ErrNotExist) {
+			compile = true
+			if m.Verbose {
+				fmt.Println("Compiling driver")
+			}
+		} else if err != nil {
+			return errors.Wrapf(err, "reading %s", hashfile)
+		}
+	}
+
+	dh := newDirHasher()
+	for _, filename := range pkg.GoFiles {
+		if err = addFileToHash(dh, filename); err != nil {
+			return errors.Wrapf(err, "hashing file %s", filename)
+		}
+	}
+	newhash, err := dh.hash()
+	if err != nil {
+		return errors.Wrapf(err, "computing hash of directory %s", m.Pkgdir)
+	}
+
+	if !compile {
+		if newhash == string(oldhash) {
+			if m.Verbose {
+				fmt.Println("Using existing driver")
+			}
+		} else {
+			compile = true
+			if m.Verbose {
+				fmt.Println("Recompiling driver")
+			}
+		}
+	}
+
+	if compile {
+		if err = Compile(ctx, m.Pkgdir, driver); err != nil {
+			return errors.Wrapf(err, "compiling driver %s", driver)
+		}
+		if err = os.WriteFile(hashfile, []byte(newhash), 0644); err != nil {
+			return errors.Wrapf(err, "writing %s", hashfile)
+		}
 	}
 
 	cmd := exec.CommandContext(ctx, driver, args...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	err = cmd.Run()
 	return errors.Wrapf(err, "running %s %s", driver, strings.Join(args, " "))
-}
-
-func (m Main) getDriver(ctx context.Context) (string, error) {
-	entries, err := os.ReadDir(m.Pkgdir)
-	if err != nil {
-		return "", errors.Wrapf(err, "reading directory %s", m.Pkgdir)
-	}
-	dh := newDirHasher()
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		if strings.HasSuffix(entry.Name(), "_test.go") {
-			continue
-		}
-		if !strings.HasSuffix(entry.Name(), ".go") {
-			continue
-		}
-		if err = addFileToHash(dh, filepath.Join(m.Pkgdir, entry.Name())); err != nil {
-			return "", errors.Wrapf(err, "hashing file %s/%s", m.Pkgdir, entry.Name())
-		}
-	}
-	dhval, err := dh.hash()
-	if err != nil {
-		return "", errors.Wrapf(err, "computing hash for directory %s", m.Pkgdir)
-	}
-
-	var (
-		driver  = filepath.Join(m.Fabdir, dhval)
-		compile bool
-	)
-	info, err := os.Stat(driver)
-	switch {
-	case errors.Is(err, fs.ErrNotExist):
-		if m.Verbose {
-			fmt.Println("Compiling driver")
-		}
-		compile = true
-	case err != nil:
-		return "", errors.Wrapf(err, "statting %s", driver)
-	case info.Mode().Perm()&1 == 0:
-		return "", fmt.Errorf("file %s exists but is not world-executable", driver)
-	case m.Force:
-		if m.Verbose {
-			fmt.Println("Forcing recompilation of driver")
-		}
-		compile = true
-	case m.Verbose:
-		fmt.Println("Using existing driver")
-	}
-
-	if !compile {
-		return driver, nil
-	}
-
-	if err = os.MkdirAll(m.Fabdir, 0755); err != nil {
-		return "", errors.Wrapf(err, "creating directory %s", m.Fabdir)
-	}
-
-	err = Compile(ctx, m.Pkgdir, driver)
-	return driver, errors.Wrapf(err, "compiling %s", driver)
 }
 
 func addFileToHash(dh *dirHasher, filename string) error {

--- a/sqlite/db.go
+++ b/sqlite/db.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"io"
+	"log"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -37,6 +39,8 @@ func Open(ctx context.Context, path string, opts ...Option) (*DB, error) {
 	}
 
 	goose.SetBaseFS(migrations)
+	goose.SetLogger(log.New(io.Discard, "", 0)) // Silence "no migrations to run" messages.
+
 	if err = goose.SetDialect("sqlite3"); err != nil {
 		return nil, errors.Wrap(err, "setting migration dialect")
 	}


### PR DESCRIPTION
The driver file is now in ~/.fab/PKGPATH/fab.bin, and the hash is in ~/.fab/PKGPATH/hash. This will prevent the accumulation of obsolete files with meaningless names in ~/.fab.