### PR TITLE
Dynamic runtime rule registry

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -115,7 +115,6 @@ func Compile(ctx context.Context, pkgdir, binfile string) error {
 		parser = dpkg.Parser()
 		pr     = dpkg.Printer()
 	)
-	pr.TextPrefix = "    "
 	for _, v := range dpkg.Vars {
 		for _, name := range v.Names {
 			if tt, ok := targets[name]; ok {

--- a/context.go
+++ b/context.go
@@ -36,22 +36,6 @@ func GetHashDB(ctx context.Context) HashDB {
 	return db
 }
 
-// WithNames decorates a context with a map[uintptr]string.
-// The keys are the addresses of Target objects
-// and the values are their "pretty names."
-// When available, these are shown to the user at runtime
-// in preference to the value of Target.ID.
-func WithNames(ctx context.Context, names map[uintptr]string) context.Context {
-	return context.WithValue(ctx, namesKeyType{}, names)
-}
-
-// GetNames returns the map[uintptr]string added to `ctx` with WithNames.
-// The default, if WithNames was not used, is nil.
-func GetNames(ctx context.Context) map[uintptr]string {
-	names, _ := ctx.Value(namesKeyType{}).(map[uintptr]string)
-	return names
-}
-
 // WithRunner decorates a context with a Runner.
 // Retrieve it with GetRunner.
 func WithRunner(ctx context.Context, r *Runner) context.Context {

--- a/context_test.go
+++ b/context_test.go
@@ -23,20 +23,6 @@ func TestWithForce(t *testing.T) {
 	}
 }
 
-func TestWithNames(t *testing.T) {
-	ctx := context.Background()
-	got := GetNames(ctx)
-	if got != nil {
-		t.Errorf("got %v, want nil", got)
-	}
-	m := make(map[uintptr]string)
-	ctx = WithNames(ctx, m)
-	got = GetNames(ctx)
-	if got == nil {
-		t.Error("got nil, want non-nil")
-	}
-}
-
 func TestWithRunner(t *testing.T) {
 	ctx := context.Background()
 	got := GetRunner(ctx)

--- a/driver.go.tmpl
+++ b/driver.go.tmpl
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -16,14 +17,16 @@ import (
 	subpkg "x/pkg/{{ .Subpkg }}"
 )
 
+var bolRegex = regexp.MustCompile("^")
+
 func main() {
-	{{ range .Targets }}
-	{{ if .IsFunc }}
+	{{- range .Targets }}
+	{{- if .IsFunc }}
 	fab.Register("{{ .Name }}", {{ .Doc }}, subpkg.{{ .Name }}())
-	{{ else }}
+	{{- else }}
 	fab.Register("{{ .Name }}", {{ .Doc }}, subpkg.{{ .Name }})
-	{{ end }}
-	{{ end }}
+	{{- end }}
+	{{- end }}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -69,6 +72,7 @@ func main() {
 		for _, name := range targetNames {
 			fmt.Println(name)
 			if _, d := fab.RegistryTarget(name); d != "" {
+				d = bolRegex.ReplaceAllString(d, "    ")
 				fmt.Println(d)
 			}
 		}

--- a/driver.go.tmpl
+++ b/driver.go.tmpl
@@ -7,44 +7,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/bobg/fab"
 	"github.com/bobg/fab/sqlite"
-	"github.com/bobg/go-generics/maps"
 
 	subpkg "x/pkg/{{ .Subpkg }}"
 )
 
 func main() {
-	index := map[string]fab.Target{
-		{{ range .Targets }}
-		"{{ .Name }}": subpkg.{{ .Name }},
-		{{ end }}
-	}
-
-	doc := map[string]string{
-		{{ range .Targets }}
-		"{{ .Name }}": {{ .Doc }},
-		{{ end }}
-	}
-
-	var (
-		names = make(map[uintptr]string)
-		v     reflect.Value
-	)
 	{{ range .Targets }}
-	v = reflect.ValueOf(subpkg.{{ .Name }})
-	if v.Kind() == reflect.Pointer {
-		names[v.Pointer()] = "{{ .Name }}"
-	}
+	fab.Register("{{ .Name }}", {{ .Doc }}, subpkg.{{ .Name }})
 	{{ end }}
 
 	ctx := context.Background()
-	ctx = fab.WithNames(ctx, names)
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -85,11 +62,10 @@ func main() {
 	}
 
 	if list {
-		targetNames := maps.Keys(index)
-		sort.Strings(targetNames)
+		targetNames := fab.RegistryNames()
 		for _, name := range targetNames {
 			fmt.Println(name)
-			if d := doc[name]; d != "" {
+			if _, d := fab.RegistryTarget(name); d != "" {
 				fmt.Println(d)
 			}
 		}
@@ -102,7 +78,7 @@ func main() {
 	)
 
 	for _, arg := range args {
-		if target, ok := index[arg]; ok {
+		if target, _ := fab.RegistryTarget(arg); target != nil {
 			targets = append(targets, target)
 		} else {
 			unknown = append(unknown, arg)

--- a/driver.go.tmpl
+++ b/driver.go.tmpl
@@ -18,10 +18,12 @@ import (
 
 func main() {
 	{{ range .Targets }}
+	{{ if .IsFunc }}
+	fab.Register("{{ .Name }}", {{ .Doc }}, subpkg.{{ .Name }}())
+	{{ else }}
 	fab.Register("{{ .Name }}", {{ .Doc }}, subpkg.{{ .Name }})
 	{{ end }}
-
-	ctx := context.Background()
+	{{ end }}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -40,6 +42,7 @@ func main() {
 	flag.BoolVar(&force, "f", false, "force rebuilding of targets")
 	flag.Parse()
 
+	ctx := context.Background()
 	ctx = fab.WithVerbose(ctx, verbose)
 	ctx = fab.WithForce(ctx, force)
 

--- a/register.go
+++ b/register.go
@@ -1,0 +1,48 @@
+package fab
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/bobg/go-generics/maps"
+)
+
+// Register places a target in the registry with a given name.
+func Register(name string, target Target) Target {
+	if h, ok := target.(HashTarget); ok {
+		target = namedHashTarget{
+			HashTarget: h,
+			n:          name,
+		}
+	} else {
+		target = namedTarget{
+			Target: target,
+			n:      name,
+		}
+	}
+	registryMu.Lock()
+	registry[name] = target
+	registryMu.Unlock()
+	return target
+}
+
+var (
+	registryMu sync.Mutex // protects registry
+	registry   = map[string]Target{}
+)
+
+// RegistryNames returns the names in the registry.
+func RegistryNames() []string {
+	registryMu.Lock()
+	keys := maps.Keys(registry)
+	registryMu.Unlock()
+	sort.Strings(keys)
+	return keys
+}
+
+// RegistryTarget returns the target in the registry with the given name.
+func RegistryTarget(name string) Target {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	return registry[name]
+}

--- a/rules.go
+++ b/rules.go
@@ -257,11 +257,11 @@ func (ft FilesTarget) Hash(ctx context.Context) ([]byte, error) {
 	)
 	err := fillWithFileHashes(ft.In, inHashes)
 	if err != nil {
-		return nil, errors.Wrapf(err, "computing input hash(es) for %s", Name(ctx, ft))
+		return nil, errors.Wrapf(err, "computing input hash(es) for %s", Name(ft))
 	}
 	err = fillWithFileHashes(ft.Out, outHashes)
 	if err != nil {
-		return nil, errors.Wrapf(err, "computing output hash(es) for %s", Name(ctx, ft))
+		return nil, errors.Wrapf(err, "computing output hash(es) for %s", Name(ft))
 	}
 	s := struct {
 		Target

--- a/runner.go
+++ b/runner.go
@@ -130,15 +130,15 @@ func (r *Runner) runTarget(ctx context.Context, db HashDB, target Target) error 
 		if ht != nil && !force {
 			h, err := ht.Hash(ctx)
 			if err != nil {
-				return errors.Wrapf(err, "computing hash for %s", Name(ctx, target))
+				return errors.Wrapf(err, "computing hash for %s", Name(target))
 			}
 			has, err := db.Has(ctx, h)
 			if err != nil {
-				return errors.Wrapf(err, "checking hash db for hash of %s", Name(ctx, target))
+				return errors.Wrapf(err, "checking hash db for hash of %s", Name(target))
 			}
 			if has {
 				if verbose {
-					r.Indentf("%s is up to date", Name(ctx, target))
+					r.Indentf("%s is up to date", Name(target))
 				}
 				return nil
 			}
@@ -146,18 +146,18 @@ func (r *Runner) runTarget(ctx context.Context, db HashDB, target Target) error 
 	}
 
 	if verbose {
-		r.Indentf("Running %s", Name(ctx, target))
+		r.Indentf("Running %s", Name(target))
 	}
 
 	err := target.Run(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "running %s", Name(ctx, target))
+		return errors.Wrapf(err, "running %s", Name(target))
 	}
 
 	if ht != nil {
 		h, err := ht.Hash(ctx)
 		if err != nil {
-			return errors.Wrapf(err, "computing new updatedhash for %s", Name(ctx, target))
+			return errors.Wrapf(err, "computing new updatedhash for %s", Name(target))
 		}
 		err = db.Add(ctx, h)
 		if err != nil {

--- a/target_test.go
+++ b/target_test.go
@@ -28,20 +28,18 @@ func TestID(t *testing.T) {
 
 func TestName(t *testing.T) {
 	t1 := F(func(_ context.Context) error { return nil })
-	ctx := context.Background()
-	got := Name(ctx, t1)
+	got := Name(t1)
 	if got != t1.ID() {
 		t.Errorf("got %s, want %s [1]", got, t1.ID())
 	}
 	names := map[uintptr]string{0: "foo"}
-	ctx = WithNames(ctx, names)
-	got = Name(ctx, t1)
+	got = Name(t1)
 	if got != t1.ID() {
 		t.Errorf("got %s, want %s [2]", got, t1.ID())
 	}
 	v := reflect.ValueOf(t1)
 	names[v.Pointer()] = "plugh"
-	got = Name(ctx, t1)
+	got = Name(t1)
 	if got != "plugh" {
 		t.Errorf("got %s, want plugh", got)
 	}

--- a/target_test.go
+++ b/target_test.go
@@ -2,7 +2,6 @@ package fab
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/bobg/go-generics/parallel"
@@ -32,14 +31,8 @@ func TestName(t *testing.T) {
 	if got != t1.ID() {
 		t.Errorf("got %s, want %s [1]", got, t1.ID())
 	}
-	names := map[uintptr]string{0: "foo"}
-	got = Name(t1)
-	if got != t1.ID() {
-		t.Errorf("got %s, want %s [2]", got, t1.ID())
-	}
-	v := reflect.ValueOf(t1)
-	names[v.Pointer()] = "plugh"
-	got = Name(t1)
+	t2 := Register("plugh", "", t1)
+	got = Name(t2)
 	if got != "plugh" {
 		t.Errorf("got %s, want plugh", got)
 	}

--- a/types.go
+++ b/types.go
@@ -52,6 +52,24 @@ func checkImplementsTarget(typ types.Type) error {
 	return nil
 }
 
+func checkIsFuncReturningTarget(typ types.Type) error {
+	sig, ok := typ.(*types.Signature)
+	if !ok {
+		return fmt.Errorf("not a function")
+	}
+	if params := sig.Params(); params != nil && params.Len() > 0 {
+		return fmt.Errorf("function takes %d arg(s), want 0", params.Len())
+	}
+	result := sig.Results()
+	if result == nil {
+		return fmt.Errorf("function returns no results, want 1")
+	}
+	if result.Len() != 1 {
+		return fmt.Errorf("function returns %d results, want 1", result.Len())
+	}
+	return checkImplementsTarget(result.At(0).Type())
+}
+
 func checkSignaturesMatch(sig *types.Signature, fn reflect.Type, skipReceiver bool) (err error) {
 	if fn.Kind() != reflect.Func {
 		return fmt.Errorf("kind is %v, not func", fn.Kind())


### PR DESCRIPTION
Rules are now maintained in a global registry that can be populated dynamically (by packages invoking `fab.Register` at initialization time) as well as statically (by defining a `Target`-typed variable). Additionally, a function of type `func() Target` (or some return type that implements `Target`) is a new way to statically register a rule - the driver will invoke the function at startup.

Removed `WithNames` and `GetNames`.