### PR TITLE
Breaking change: Target naming

### DIFF
--- a/_testdata/compile/go.mod
+++ b/_testdata/compile/go.mod
@@ -5,13 +5,15 @@ go 1.18
 require github.com/bobg/fab v0.8.0
 
 require (
-	github.com/fatih/camelcase v1.0.0 // indirect
+	github.com/bobg/go-generics v1.2.0 // indirect
 	github.com/gibson042/canonicaljson-go v1.0.3 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24 // indirect
 	golang.org/x/tools v0.1.12 // indirect
 )
+
+replace github.com/bobg/fab => ../fab

--- a/_testdata/compile/pkg/rules.go
+++ b/_testdata/compile/pkg/rules.go
@@ -2,8 +2,8 @@ package rules
 
 import "github.com/bobg/fab"
 
-var Noop = &fab.Command{Shell: "sh -c 'echo hello'"}
+var Noop = fab.Command("sh -c 'echo hello'")
 
-var notExported = &fab.Command{Shell: "sh -c 'echo not exported'"}
+var notExported = fab.Command("sh -c 'echo not exported'")
 
 var NotATarget = 17

--- a/clean_test.go
+++ b/clean_test.go
@@ -24,7 +24,7 @@ func TestClean(t *testing.T) {
 	}
 
 	r := NewRunner()
-	if err = r.Run(context.Background(), &Clean{Files: []string{tmpname, "/tmp/i-hope-i-am-a-file-that-does-not-exist"}}); err != nil {
+	if err = r.Run(context.Background(), Clean(tmpname, "/tmp/i-hope-i-am-a-file-that-does-not-exist")); err != nil {
 		t.Fatal(err)
 	}
 

--- a/command.go
+++ b/command.go
@@ -1,0 +1,169 @@
+package fab
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/mattn/go-shellwords"
+)
+
+// Command is a target whose Run function executes a command in a subprocess.
+func Command(cmd string, opts ...CommandOpt) Target {
+	c := &command{
+		Namer: NewNamer("Command"),
+		Shell: cmd,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+type command struct {
+	*Namer
+
+	// Shell is the command to run,
+	// as a single string with command name and arguments together.
+	// It is parsed as if by a Unix shell,
+	// with quoting and so on,
+	// in order to produce the command name
+	// and a list of individual argument strings.
+	//
+	// To bypass this parsing behavior,
+	// you may specify Cmd and Args directly.
+	Shell string `json:"shell,omitempty"`
+
+	// Cmd is the command to invoke,
+	// either the path to a file,
+	// or an executable file found in some directory
+	// named in the PATH environment variable.
+	//
+	// Leave Cmd blank and specify Shell instead
+	// to get shell-like parsing of a command and its arguments.
+	Cmd string `json:"cmd,omitempty"`
+
+	// Args is the list of command-line arguments
+	// to pass to the command named in Cmd.
+	Args []string `json:"args,omitempty"`
+
+	// Stdout and Stderr tell where to send the command's output.
+	// If either or both is nil,
+	// that output is saved in case the subprocess encounters an error.
+	// Then the returned error is a CommandErr containing that output.
+	Stdout io.Writer `json:"-"`
+	Stderr io.Writer `json:"-"`
+
+	// Dir is the directory in which to run the command.
+	// The default is the value of GetDir(ctx) when the Run method is called.
+	Dir string `json:"dir,omitempty"`
+
+	// Env is a list of VAR=VALUE strings to add to the environment when the command runs.
+	Env []string `json:"env,omitempty"`
+}
+
+var _ Target = &command{}
+
+type CommandOpt func(*command)
+
+func CmdArgs(args ...string) CommandOpt {
+	return func(c *command) {
+		c.Cmd = c.Shell
+		c.Args = args
+	}
+}
+
+func CmdStdout(w io.Writer) CommandOpt {
+	return func(c *command) {
+		c.Stdout = w
+	}
+}
+
+func CmdStderr(w io.Writer) CommandOpt {
+	return func(c *command) {
+		c.Stderr = w
+	}
+}
+
+func CmdDir(dir string) CommandOpt {
+	return func(c *command) {
+		c.Dir = dir
+	}
+}
+
+func CmdEnv(env []string) CommandOpt {
+	return func(c *command) {
+		c.Env = env
+	}
+}
+
+// Run implements Target.Run.
+func (c *command) Run(ctx context.Context) error {
+	cmdname, args, err := c.getCmdAndArgs()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(ctx, cmdname, args...)
+
+	cmd.Dir = c.Dir
+	cmd.Env = append(os.Environ(), c.Env...)
+
+	var buf bytes.Buffer
+	cmd.Stdout, cmd.Stderr = c.Stdout, c.Stderr
+	if c.Stdout == nil {
+		cmd.Stdout = &buf
+	}
+	if c.Stderr == nil {
+		cmd.Stderr = &buf
+	}
+
+	if GetVerbose(ctx) {
+		Indentf(ctx, "  Running command %s", cmd)
+	}
+
+	err = cmd.Run()
+	if err != nil && buf.Len() > 0 {
+		err = CommandErr{
+			Err:    err,
+			Output: buf.Bytes(),
+		}
+	}
+	return err
+}
+
+func (c *command) getCmdAndArgs() (string, []string, error) {
+	if c.Cmd != "" {
+		return c.Cmd, c.Args, nil
+	}
+	words, err := shellwords.Parse(c.Shell)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(words) == 0 {
+		return "", nil, fmt.Errorf("empty shell command")
+	}
+	return words[0], words[1:], nil
+}
+
+// CommandErr is a type of error that may be returned from command.Run.
+// If the command's Stdout or Stderr field was nil,
+// then that output from the subprocess is in CommandErr.Output
+// and the underlying error is in CommandErr.Err.
+type CommandErr struct {
+	Err    error
+	Output []byte
+}
+
+// Error implements error.Error.
+func (e CommandErr) Error() string {
+	return fmt.Sprintf("%s; output follows\n%s", e.Err, string(e.Output))
+}
+
+// Unwrap produces the underlying error.
+func (e CommandErr) Unwrap() error {
+	return e.Err
+}

--- a/compile.go
+++ b/compile.go
@@ -156,9 +156,6 @@ func Compile(ctx context.Context, pkgdir, binfile string) error {
 		}
 	}
 
-	type templateTarget struct {
-		Name, Doc string
-	}
 	data := struct {
 		Subpkg  string
 		Targets []*targetPair

--- a/compile_test.go
+++ b/compile_test.go
@@ -124,6 +124,10 @@ func tbCompile(tb testing.TB, f func(tmpdir, pkgdir string)) {
 	}
 	defer os.RemoveAll(tmpdir)
 
+	if err = populateFabDir(tmpdir); err != nil {
+		tb.Fatal(err)
+	}
+
 	compiledir := filepath.Join(tmpdir, "compile")
 
 	if err = copy.Copy("_testdata/compile", compiledir); err != nil {

--- a/embeds.go
+++ b/embeds.go
@@ -5,12 +5,5 @@ import "embed"
 //go:embed *.go go.* driver.go.tmpl deps sqlite
 var embeds embed.FS
 
+//go:embed driver.go.tmpl
 var driverStr string
-
-func init() {
-	driverBytes, err := embeds.ReadFile("driver.go.tmpl")
-	if err != nil {
-		panic(err)
-	}
-	driverStr = string(driverBytes)
-}

--- a/fab.d/fab.go
+++ b/fab.d/fab.go
@@ -7,28 +7,16 @@ import (
 )
 
 // Build runs "go build".
-var Build = &fab.Command{
-	Shell:  "go build ./...",
-	Stdout: os.Stdout,
-}
+var Build = fab.Command("go build ./...", fab.CmdStdout(os.Stdout))
 
 // Test runs "go test" with the race detector enabled, plus coverage reporting.
-var Test = &fab.Command{
-	Shell:  "go test -race -cover ./...",
-	Stdout: os.Stdout,
-}
+var Test = fab.Command("go test -race -cover ./...", fab.CmdStdout(os.Stdout))
 
 // Lint runs staticcheck.
-var Lint = &fab.Command{
-	Shell:  "staticcheck ./...",
-	Stdout: os.Stdout,
-}
+var Lint = fab.Command("staticcheck ./...", fab.CmdStdout(os.Stdout))
 
 // Vet runs "go vet".
-var Vet = &fab.Command{
-	Shell:  "go vet ./...",
-	Stdout: os.Stdout,
-}
+var Vet = fab.Command("go vet ./...", fab.CmdStdout(os.Stdout))
 
 // Check runs all of Vet, Lint, and Test.
 var Check = fab.All(Vet, Lint, Test)

--- a/hash_test.go
+++ b/hash_test.go
@@ -32,11 +32,9 @@ func TestHashTarget(t *testing.T) {
 	}
 
 	fc := &FilesTarget{
-		Target: &Command{
-			Shell: fmt.Sprintf("sh -c 'cat %s >> %s'", inpath, outpath),
-		},
-		In:  []string{inpath},
-		Out: []string{outpath},
+		Target: Command(fmt.Sprintf("sh -c 'cat %s >> %s'", inpath, outpath)),
+		In:     []string{inpath},
+		Out:    []string{outpath},
 	}
 
 	ctx := context.Background()

--- a/main_test.go
+++ b/main_test.go
@@ -16,8 +16,12 @@ func TestMain(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
+	if err = populateFabDir(tmpdir); err != nil {
+		t.Fatal(err)
+	}
+
 	var (
-		fabdir     = filepath.Join(tmpdir, "fab")
+		fabdir     = filepath.Join(tmpdir, ".fab")
 		compiledir = filepath.Join(tmpdir, "compile")
 	)
 	if err = os.Mkdir(fabdir, 0755); err != nil {

--- a/namer.go
+++ b/namer.go
@@ -1,0 +1,43 @@
+package fab
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+type Namer struct {
+	mu         sync.Mutex
+	base, name string
+}
+
+func NewNamer(base string) *Namer {
+	return &Namer{base: base}
+}
+
+func (n *Namer) Name() string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.name == "" {
+		if n.base == "" {
+			n.name = Unique(n.base)
+		} else {
+			n.name = Unique("target")
+		}
+	}
+	return n.name
+}
+
+func (n *Namer) SetName(name string) {
+	n.mu.Lock()
+	n.name = name
+	n.mu.Unlock()
+}
+
+var uniquecounter uint32
+
+// Unique produces a unique string by appending a unique counter value to the given prefix.
+// For example, Unique("Foo") might produce "Foo-17".
+func Unique(s string) string {
+	return fmt.Sprintf("%s-%d", s, atomic.AddUint32(&uniquecounter, 1))
+}

--- a/register.go
+++ b/register.go
@@ -9,17 +9,7 @@ import (
 
 // Register places a target in the registry with a given name.
 func Register(name, doc string, target Target) Target {
-	if h, ok := target.(HashTarget); ok {
-		target = namedHashTarget{
-			HashTarget: h,
-			n:          name,
-		}
-	} else {
-		target = namedTarget{
-			Target: target,
-			n:      name,
-		}
-	}
+	target.SetName(name)
 	registryMu.Lock()
 	registry[name] = targetDocPair{target: target, doc: doc}
 	registryMu.Unlock()

--- a/register_test.go
+++ b/register_test.go
@@ -6,15 +6,14 @@ import (
 )
 
 func TestRegister(t *testing.T) {
-	var (
-		target     Target
-		hashTarget HashTarget
-	)
-	Register("target", "target doc", target)
-	Register("hash_target", "hash_target doc", hashTarget)
+	target := Register("target", "target doc", &countTarget{Namer: NewNamer("count")})
+
+	if n := target.Name(); n != "target" {
+		t.Errorf("got name %s, want target", n)
+	}
 
 	gotNames := RegistryNames()
-	wantNames := []string{"hash_target", "target"}
+	wantNames := []string{"target"}
 	if !reflect.DeepEqual(gotNames, wantNames) {
 		t.Errorf("got %v, want %v", gotNames, wantNames)
 	}
@@ -23,10 +22,7 @@ func TestRegister(t *testing.T) {
 	if gotDoc != "target doc" {
 		t.Errorf(`got "%s", want "target doc"`, gotDoc)
 	}
-	_, gotDoc = RegistryTarget("hash_target")
-	if gotDoc != "hash_target doc" {
-		t.Errorf(`got "%s", want "hash_target doc"`, gotDoc)
-	}
+
 	gotTarget, _ := RegistryTarget("foobie_bletch")
 	if gotTarget != nil {
 		t.Errorf(`got non-nil target for "foobie_bletch", want nil`)

--- a/rules.go
+++ b/rules.go
@@ -1,28 +1,24 @@
 package fab
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 
-	"github.com/mattn/go-shellwords"
 	"github.com/pkg/errors"
 )
 
 // All produces a target that runs a collection of targets in parallel.
 func All(targets ...Target) Target {
-	return &all{targets: targets}
+	return &all{Namer: NewNamer("all"), targets: targets}
 }
 
 type all struct {
+	*Namer
 	targets []Target
-	id      string
 }
 
 var _ Target = &all{}
@@ -32,23 +28,15 @@ func (a *all) Run(ctx context.Context) error {
 	return Run(ctx, a.targets...)
 }
 
-// ID implements Target.ID.
-func (a *all) ID() string {
-	if a.id == "" {
-		a.id = ID("All")
-	}
-	return a.id
-}
-
 // Seq produces a target that runs a collection of targets in sequence.
 // Its Run method exits early when a target in the sequence fails.
 func Seq(targets ...Target) Target {
-	return &seq{targets: targets}
+	return &seq{Namer: NewNamer("Seq"), targets: targets}
 }
 
 type seq struct {
+	*Namer
 	targets []Target
-	id      string
 }
 
 var _ Target = &seq{}
@@ -63,14 +51,6 @@ func (s *seq) Run(ctx context.Context) error {
 	return nil
 }
 
-// ID implements Target.ID.
-func (s *seq) ID() string {
-	if s.id == "" {
-		s.id = ID("Seq")
-	}
-	return s.id
-}
-
 // Deps wraps a target with a set of dependencies,
 // making sure those run first.
 //
@@ -81,12 +61,12 @@ func Deps(target Target, depTargets ...Target) Target {
 
 // F produces a target whose Run function invokes the given function.
 func F(f func(context.Context) error) Target {
-	return &ftarget{f: f}
+	return &ftarget{Namer: NewNamer("F"), f: f}
 }
 
 type ftarget struct {
-	f  func(context.Context) error
-	id string
+	*Namer
+	f func(context.Context) error
 }
 
 var _ Target = &ftarget{}
@@ -94,135 +74,6 @@ var _ Target = &ftarget{}
 // Run implements Target.Run.
 func (f *ftarget) Run(ctx context.Context) error {
 	return f.f(ctx)
-}
-
-// ID implements Target.ID.
-func (f *ftarget) ID() string {
-	if f.id == "" {
-		f.id = ID("F")
-	}
-	return f.id
-}
-
-// Command is a target whose Run function executes a command in a subprocess.
-type Command struct {
-	// Shell is the command to run,
-	// as a single string with command name and arguments together.
-	// It is parsed as if by a Unix shell,
-	// with quoting and so on,
-	// in order to produce the command name
-	// and a list of individual argument strings.
-	//
-	// To bypass this parsing behavior,
-	// you may specify Cmd and Args directly.
-	Shell string `json:"shell,omitempty"`
-
-	// Cmd is the command to invoke,
-	// either the path to a file,
-	// or an executable file found in some directory
-	// named in the PATH environment variable.
-	//
-	// Leave Cmd blank and specify Shell instead
-	// to get shell-like parsing of a command and its arguments.
-	Cmd string `json:"cmd,omitempty"`
-
-	// Args is the list of command-line arguments
-	// to pass to the command named in Cmd.
-	Args []string `json:"args,omitempty"`
-
-	// Stdout and Stderr tell where to send the command's output.
-	// If either or both is nil,
-	// that output is saved in case the subprocess encounters an error.
-	// Then the returned error is a CommandErr containing that output.
-	Stdout io.Writer `json:"-"`
-	Stderr io.Writer `json:"-"`
-
-	// Dir is the directory in which to run the command.
-	// The default is the value of GetDir(ctx) when the Run method is called.
-	Dir string `json:"dir,omitempty"`
-
-	// Env is a list of VAR=VALUE strings to add to the environment when the command runs.
-	Env []string `json:"env,omitempty"`
-
-	id string
-}
-
-var _ Target = &Command{}
-
-// Run implements Target.Run.
-func (c *Command) Run(ctx context.Context) error {
-	cmdname, args, err := c.getCmdAndArgs()
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.CommandContext(ctx, cmdname, args...)
-
-	cmd.Dir = c.Dir
-	cmd.Env = append(os.Environ(), c.Env...)
-
-	var buf bytes.Buffer
-	cmd.Stdout, cmd.Stderr = c.Stdout, c.Stderr
-	if c.Stdout == nil {
-		cmd.Stdout = &buf
-	}
-	if c.Stderr == nil {
-		cmd.Stderr = &buf
-	}
-
-	if GetVerbose(ctx) {
-		Indentf(ctx, "  Running command %s", cmd)
-	}
-
-	err = cmd.Run()
-	if err != nil && buf.Len() > 0 {
-		err = CommandErr{
-			Err:    err,
-			Output: buf.Bytes(),
-		}
-	}
-	return err
-}
-
-// ID implements Target.ID.
-func (c *Command) ID() string {
-	if c.id == "" {
-		c.id = ID("Command")
-	}
-	return c.id
-}
-
-func (c *Command) getCmdAndArgs() (string, []string, error) {
-	if c.Cmd != "" {
-		return c.Cmd, c.Args, nil
-	}
-	words, err := shellwords.Parse(c.Shell)
-	if err != nil {
-		return "", nil, err
-	}
-	if len(words) == 0 {
-		return "", nil, fmt.Errorf("empty shell command")
-	}
-	return words[0], words[1:], nil
-}
-
-// CommandErr is a type of error that may be returned from Command.Run.
-// If the Command's Stdout or Stderr field was nil,
-// then that output from the subprocess is in CommandErr.Output
-// and the underlying error is in CommandErr.Err.
-type CommandErr struct {
-	Err    error
-	Output []byte
-}
-
-// Error implements error.Error.
-func (e CommandErr) Error() string {
-	return fmt.Sprintf("%s; output follows\n%s", e.Err, string(e.Output))
-}
-
-// Unwrap produces the underlying error.
-func (e CommandErr) Unwrap() error {
-	return e.Err
 }
 
 // FilesTarget is a HashTarget.
@@ -257,11 +108,11 @@ func (ft FilesTarget) Hash(ctx context.Context) ([]byte, error) {
 	)
 	err := fillWithFileHashes(ft.In, inHashes)
 	if err != nil {
-		return nil, errors.Wrapf(err, "computing input hash(es) for %s", Name(ft))
+		return nil, errors.Wrapf(err, "computing input hash(es) for %s", ft.Name())
 	}
 	err = fillWithFileHashes(ft.Out, outHashes)
 	if err != nil {
-		return nil, errors.Wrapf(err, "computing output hash(es) for %s", Name(ft))
+		return nil, errors.Wrapf(err, "computing output hash(es) for %s", ft.Name())
 	}
 	s := struct {
 		Target
@@ -310,16 +161,8 @@ func hashFile(path string) ([]byte, error) {
 // Clean is a Target that deletes the files named in Files when it runs.
 // Files that don't exist are silently ignored.
 type Clean struct {
+	Namer
 	Files []string
-	id    string
-}
-
-// ID implements Target.ID.
-func (c *Clean) ID() string {
-	if c.id == "" {
-		c.id = ID("Clean")
-	}
-	return c.id
 }
 
 // Run implements Target.Run.

--- a/rules.go
+++ b/rules.go
@@ -160,13 +160,20 @@ func hashFile(path string) ([]byte, error) {
 
 // Clean is a Target that deletes the files named in Files when it runs.
 // Files that don't exist are silently ignored.
-type Clean struct {
-	Namer
+func Clean(files ...string) Target {
+	return &clean{
+		Namer: NewNamer("Clean"),
+		Files: files,
+	}
+}
+
+type clean struct {
+	*Namer
 	Files []string
 }
 
 // Run implements Target.Run.
-func (c *Clean) Run(_ context.Context) error {
+func (c *clean) Run(_ context.Context) error {
 	for _, f := range c.Files {
 		err := os.Remove(f)
 		if errors.Is(err, fs.ErrNotExist) {

--- a/runner_test.go
+++ b/runner_test.go
@@ -13,7 +13,7 @@ func TestRunTarget(t *testing.T) {
 	var (
 		ctx     = context.Background()
 		r       = NewRunner()
-		ct      countTarget
+		ct      = countTarget{Namer: NewNamer("count")}
 		targets []Target
 	)
 
@@ -51,16 +51,13 @@ func TestRunTarget(t *testing.T) {
 }
 
 type countTarget struct {
+	*Namer
 	count uint32
 }
 
 func (ct *countTarget) Run(_ context.Context) error {
 	atomic.AddUint32(&ct.count, 1)
 	return nil
-}
-
-func (ct *countTarget) ID() string {
-	return "ct"
 }
 
 func (ct *countTarget) Hash(_ context.Context) ([]byte, error) {

--- a/target.go
+++ b/target.go
@@ -2,8 +2,6 @@ package fab
 
 import (
 	"context"
-	"fmt"
-	"sync/atomic"
 )
 
 // Target is the interface that Fab targets must implement.
@@ -18,46 +16,12 @@ type Target interface {
 	// when it doesn't need to be.
 	Run(context.Context) error
 
-	// ID is a unique ID for the target.
-	// Each instance of each Target must have a persistent, unique ID.
-	// The ID function can help with that.
-	ID() string
+	// Name is a unique name for the target.
+	// Each instance of each Target must have a persistent, unique name.
+	// You can embed a Namer in your concrete type to achieve this.
+	Name() string
+
+	// SetName sets the name of this target.
+	// The name must be unique across all targets.
+	SetName(string)
 }
-
-var idcounter uint32
-
-// ID produces an ID string by appending a unique counter value to the given prefix.
-// For example, ID("Foo") might produce "Foo-17".
-func ID(prefix string) string {
-	return fmt.Sprintf("%s-%d", prefix, atomic.AddUint32(&idcounter, 1))
-}
-
-// Name returns a name for `target`.
-// Normally this is just target.ID().
-// But Register can wrap a target with a human-friendlier name
-// and in that case Name will return that string instead.
-func Name(target Target) string {
-	if w, ok := target.(nameWrapper); ok {
-		return w.name()
-	}
-	return target.ID()
-}
-
-type nameWrapper interface {
-	Target
-	name() string
-}
-
-type namedTarget struct {
-	Target
-	n string
-}
-
-func (t namedTarget) name() string { return t.n }
-
-type namedHashTarget struct {
-	HashTarget
-	n string
-}
-
-func (t namedHashTarget) name() string { return t.n }

--- a/target_test.go
+++ b/target_test.go
@@ -8,17 +8,17 @@ import (
 	"github.com/bobg/go-generics/set"
 )
 
-func TestID(t *testing.T) {
-	// Producing any number of id's, even concurrently, should never produce a duplicate.
+func TestUnique(t *testing.T) {
+	// Producing any number of unique names, even concurrently, should never produce a duplicate.
 
 	const count = 5000
 
-	ids := parallel.Producers(context.Background(), count, func(_ context.Context, _ int, send func(id string) error) error {
-		return send(ID("x"))
+	names := parallel.Producers(context.Background(), count, func(_ context.Context, _ int, send func(name string) error) error {
+		return send(Unique("x"))
 	})
 	s := set.New[string]()
-	for ids.Next() {
-		s.Add(ids.Val())
+	for names.Next() {
+		s.Add(names.Val())
 	}
 	if s.Len() != count {
 		t.Errorf("got %d distinct values, want %d", s.Len(), count)
@@ -27,12 +27,12 @@ func TestID(t *testing.T) {
 
 func TestName(t *testing.T) {
 	t1 := F(func(_ context.Context) error { return nil })
-	got := Name(t1)
-	if got != t1.ID() {
-		t.Errorf("got %s, want %s [1]", got, t1.ID())
+	got := t1.Name()
+	if got != t1.Name() {
+		t.Errorf("got %s, want %s [1]", got, t1.Name())
 	}
 	t2 := Register("plugh", "", t1)
-	got = Name(t2)
+	got = t2.Name()
 	if got != "plugh" {
 		t.Errorf("got %s, want plugh", got)
 	}

--- a/types.go
+++ b/types.go
@@ -12,11 +12,10 @@ import (
 var targetMethods = make(map[string]reflect.Method)
 
 // nullTarget is here so we can get reflection info about Target
-type nullTarget struct{}
+type nullTarget struct{ *Namer }
 
 var _ Target = nullTarget{}
 
-func (nullTarget) ID() string                { return "" }
 func (nullTarget) Run(context.Context) error { return nil }
 
 func init() {


### PR DESCRIPTION
This PR replaces the `Target` interface's `ID` method with `Name` and `SetName`. It also introduces `Namer`, a type that `Target` implementations can embed to get `Name` and `SetName` behavior.

The result of `Name` must be unique; as with `ID` before it, it's how a `Runner` knows whether it's seen a given `Target` before. A `Namer` can help ensure the name is unique.

A call to `Register` calls the target's `SetName` method. There no longer is any idea of a name "wrapper" for targets; names are intrinsic to targets.

Because a `Namer` must be embedded as a pointer, it has to be initialized, and so types line `Command` and `Clean` can no longer be initialized ergonomically with simple struct literals. So they are now constructor functions instead, for unexported struct types.