### PR TITLE
Factor out CompilePackage; add back recursion to deps.Go

### DIFF
--- a/deps/go.go
+++ b/deps/go.go
@@ -14,13 +14,18 @@ import (
 // It traverses package dependencies transitively,
 // but only within the original package's module.
 // The list is sorted for consistent, predictable results.
-func Go(dir string) ([]string, error) {
+func Go(dir string, recursive bool) ([]string, error) {
 	config := &packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles | packages.NeedEmbedFiles | packages.NeedEmbedPatterns | packages.NeedTypes | packages.NeedDeps | packages.NeedImports | packages.NeedModule,
 		Dir:  dir,
 	}
 
-	pkgs, err := packages.Load(config, ".")
+	arg := "."
+	if recursive {
+		arg = "./..."
+	}
+
+	pkgs, err := packages.Load(config, arg)
 	if err != nil {
 		return nil, errors.Wrapf(err, "loading package from %s", dir)
 	}

--- a/deps/go_test.go
+++ b/deps/go_test.go
@@ -16,7 +16,7 @@ func TestGo(t *testing.T) {
 		"proto.go",
 	}
 
-	got, err := Go(".")
+	got, err := Go(".", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -74,11 +74,11 @@ func (m Main) Run(ctx context.Context) error {
 
 func (m Main) getDriver(ctx context.Context) (string, error) {
 	config := &packages.Config{
-		Mode:    packages.NeedName | packages.NeedFiles,
+		Mode:    LoadMode,
 		Context: ctx,
 		Dir:     m.Pkgdir,
 	}
-	pkgs, err := packages.Load(config, "./...")
+	pkgs, err := packages.Load(config, ".")
 	if err != nil {
 		return "", errors.Wrapf(err, "loading %s", m.Pkgdir)
 	}
@@ -136,7 +136,7 @@ func (m Main) getDriver(ctx context.Context) (string, error) {
 	}
 
 	dh := newDirHasher()
-	for _, filename := range pkg.GoFiles {
+	for _, filename := range pkg.GoFiles { // xxx other files too?
 		if err = addFileToHash(dh, filename); err != nil {
 			return "", errors.Wrapf(err, "hashing file %s", filename)
 		}
@@ -160,7 +160,7 @@ func (m Main) getDriver(ctx context.Context) (string, error) {
 	}
 
 	if compile {
-		if err = Compile(ctx, m.Pkgdir, driver); err != nil {
+		if err = CompilePackage(ctx, pkg, driver); err != nil {
 			return "", errors.Wrapf(err, "compiling driver %s", driver)
 		}
 		if err = os.WriteFile(hashfile, []byte(newhash), 0644); err != nil {

--- a/rules/tsdecls.go
+++ b/rules/tsdecls.go
@@ -13,7 +13,7 @@ import (
 
 // Tsdecls
 func Tsdecls(dir, typename, prefix, outfile string) (fab.Target, error) {
-	gopkg, err := deps.Go(dir)
+	gopkg, err := deps.Go(dir, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting deps for %s", dir)
 	}


### PR DESCRIPTION
This PR factors out the `CompilePackage` function to eliminate some duplicate work in the driver. It adds back recursion to `deps.Go` in the form of a new boolean parameter.