### PR TITLE
Autoclean

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,5 @@
+linters:
+  enable:
+    - gocritic
+    - godot
+    - revive

--- a/clean_test.go
+++ b/clean_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/bobg/errors"
@@ -24,7 +25,13 @@ func TestClean(t *testing.T) {
 	}
 
 	con := NewController("")
-	if err = con.Run(context.Background(), Clean(tmpname, "/tmp/i-hope-i-am-a-file-that-does-not-exist")); err != nil {
+	clean := &Clean{
+		Files: []string{
+			tmpname,
+			"/tmp/i-hope-i-am-a-file-that-does-not-exist",
+		},
+	}
+	if err = con.Run(context.Background(), clean); err != nil {
 		t.Fatal(err)
 	}
 
@@ -36,5 +43,45 @@ func TestClean(t *testing.T) {
 		t.Fatal(err)
 	default:
 		t.Errorf("failed to remove %s", tmpname)
+	}
+}
+
+func TestAutoclean(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "fab")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	path := filepath.Join(tmpdir, "outfile")
+
+	mkfile := F(func(context.Context, *Controller) error {
+		return os.WriteFile(path, []byte("Professor Little Old Man!"), 0644)
+	})
+	files := Files(mkfile, nil, []string{path}, Autoclean(true))
+
+	var (
+		con = NewController("")
+		ctx = context.Background()
+	)
+
+	ctx = WithVerbose(ctx, testing.Verbose())
+
+	if err = con.Run(ctx, files); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = con.Run(ctx, &Clean{Autoclean: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(path)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("got %v, want %v", err, fs.ErrNotExist)
 	}
 }

--- a/command.go
+++ b/command.go
@@ -258,16 +258,19 @@ func (c *Command) Run(ctx context.Context, con *Controller) (err error) {
 	}
 
 	if stderrFile != "" {
-		if stdoutFile == stderrFile {
+		switch {
+		case stdoutFile == stderrFile:
 			cmd.Stderr = cmd.Stdout
-		} else if stderrAppend {
+
+		case stderrAppend:
 			f, err := os.OpenFile(stderrFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 			if err != nil {
 				return errors.Wrapf(err, "opening %s for appending", stderrFile)
 			}
 			defer f.Close()
 			cmd.Stderr = f
-		} else {
+
+		default:
 			f, err := os.Create(stderrFile)
 			if err != nil {
 				return errors.Wrapf(err, "opening %s for writing", stderrFile)
@@ -504,7 +507,7 @@ func (c commandYAML) toTarget(con *Controller, shell, dir string, args, env []st
 
 func deferredIndent(w io.Writer) func(context.Context, *Controller) io.Writer {
 	return func(_ context.Context, con *Controller) io.Writer {
-		return con.IndentingCopier(os.Stdout, "    ")
+		return con.IndentingCopier(w, "    ")
 	}
 }
 

--- a/driver.go.tmpl
+++ b/driver.go.tmpl
@@ -63,7 +63,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	db, err := fab.OpenHashDB(ctx, fabdir)
+	db, err := fab.OpenHashDB(fabdir)
 	if err != nil {
 		fatalf("Error opening hash DB: %s", err)
 	}

--- a/fab.yaml
+++ b/fab.yaml
@@ -36,8 +36,8 @@ CoverOut: !Files
   Out: [cover.out]
   Target: !Command
     Shell: go test -coverprofile cover.out ./...
+  Autoclean: true
 
 # Clean removes build-target output.
 Clean: !Clean
-  - fab
-  - cover.out
+  Autoclean: true

--- a/files.go
+++ b/files.go
@@ -110,7 +110,7 @@ func (ft *files) Run(ctx context.Context, con *Controller) error {
 	db := GetHashDB(ctx)
 
 	if db != nil && !GetForce(ctx) && !GetDryRun(ctx) {
-		h, err := ft.computeHash(ctx, con)
+		h, err := ft.computeHash(con)
 		if err != nil {
 			return errors.Wrap(err, "computing hash before running subtarget")
 		}
@@ -134,7 +134,7 @@ func (ft *files) Run(ctx context.Context, con *Controller) error {
 		return nil
 	}
 
-	h, err := ft.computeHash(ctx, con)
+	h, err := ft.computeHash(con)
 	if err != nil {
 		return errors.Wrap(err, "computing hash after running subtarget")
 	}
@@ -147,7 +147,7 @@ func (*files) Desc() string {
 	return "Files"
 }
 
-func (ft *files) computeHash(ctx context.Context, con *Controller) ([]byte, error) {
+func (ft *files) computeHash(con *Controller) ([]byte, error) {
 	inHashes, err := fileHashes(ft.In)
 	if err != nil {
 		return nil, errors.Wrapf(err, "computing input hash(es) for %s", con.Describe(ft))

--- a/files.go
+++ b/files.go
@@ -32,8 +32,7 @@ var filesRegistry = newRegistry[*files]()
 // then the output files are up to date and running of this Files target can be skipped.
 //
 // The nested subtarget must be of a type that can be JSON-marshaled.
-// Note that this excludes [F],
-// among others.
+// Notably this excludes [F].
 //
 // When a Files target runs,
 // it checks to see whether any of its input files
@@ -45,6 +44,12 @@ var filesRegistry = newRegistry[*files]()
 // plus any transitive dependencies.
 // See the Deps function in the golang subpackage
 // for an example of a function that can compute such a list for a Go package.
+//
+// Passing Autoclean(true) as one of the options
+// causes the output files to be added to the "autoclean registry."
+// A [Clean] target may then choose to remove the files listed in that registry
+// (instead of, or in addition to, any explicitly listed files)
+// by setting its Autoclean field to true.
 //
 // When [GetDryRun] is true,
 // checking and updating of the hash DB is skipped.
@@ -70,11 +75,15 @@ var filesRegistry = newRegistry[*files]()
 // which runs the given `go build` command
 // to update the output file `thingify`
 // when any files depended on by the Go package in `cmd` change.
-func Files(target Target, in, out []string) Target {
+func Files(target Target, in, out []string, opts ...FilesOpt) Target {
 	result := &files{
 		Target: target,
 		In:     in,
 		Out:    out,
+	}
+
+	for _, opt := range opts {
+		opt(result)
 	}
 
 	for _, o := range out {
@@ -183,6 +192,26 @@ func (ft *files) runPrereqs(ctx context.Context, con *Controller) error {
 	return con.Run(ctx, prereqs...)
 }
 
+type FilesOpt func(*files)
+
+// Autoclean is an option for passing to [Files].
+// It causes the output files of the Files target to be added to the "autoclean registry."
+// A [Clean] target may then choose to remove the files listed in that registry
+// (instead of, or in addition to, any explicitly listed files)
+// by setting its Autoclean field to true.
+func Autoclean(autoclean bool) FilesOpt {
+	return func(f *files) {
+		if !autoclean {
+			return
+		}
+		autocleanMu.Lock()
+		for _, file := range f.Out {
+			autocleanRegistry.Add(file)
+		}
+		autocleanMu.Unlock()
+	}
+}
+
 // Returns [filename, hash, filename, hash, ...],
 // with filenames sorted.
 // Input is a list of file or directory names.
@@ -266,9 +295,10 @@ func filesDecoder(con *Controller, node *yaml.Node, dir string) (Target, error) 
 	}
 
 	var yfiles struct {
-		In     yaml.Node `yaml:"In"`
-		Out    yaml.Node `yaml:"Out"`
-		Target yaml.Node `yaml:"Target"`
+		In        yaml.Node `yaml:"In"`
+		Out       yaml.Node `yaml:"Out"`
+		Target    yaml.Node `yaml:"Target"`
+		Autoclean bool      `yaml:"Autoclean"`
 	}
 	if err := node.Decode(&yfiles); err != nil {
 		return nil, errors.Wrap(err, "YAML error in Files node")
@@ -289,7 +319,7 @@ func filesDecoder(con *Controller, node *yaml.Node, dir string) (Target, error) 
 		return nil, errors.Wrap(err, "YAML error in Files.Out node")
 	}
 
-	return Files(target, in, out), nil
+	return Files(target, in, out, Autoclean(yfiles.Autoclean)), nil
 }
 
 func init() {

--- a/golang/go.go
+++ b/golang/go.go
@@ -18,6 +18,10 @@ import (
 // it defaults to the last path element of dir.
 // Additional command-line arguments for `go build` can be specified with `flags`.
 //
+// Binary is implemented in terms of [fab.Files],
+// and the output file is automatically selected for "autocleaning."
+// See [fab.Autoclean] for more about this feature.
+//
 // A Binary target may be specified in YAML using the tag !go.Binary,
 // which introduces a mapping whose fields are:
 //
@@ -48,7 +52,7 @@ func Binary(dir, outfile string, flags ...string) (fab.Target, error) {
 		Cmd:  "go",
 		Args: args,
 	}
-	return fab.Files(c, deps, []string{outfile}), nil
+	return fab.Files(c, deps, []string{outfile}, fab.Autoclean(true)), nil
 }
 
 // MustBinary is the same as [Binary] but panics on error.

--- a/golang/go_test.go
+++ b/golang/go_test.go
@@ -28,7 +28,7 @@ func TestBinary(t *testing.T) {
 		outfile   = filepath.Join(tmpdir, "out")
 	)
 
-	db, err := fab.OpenHashDB(ctx, fabdir)
+	db, err := fab.OpenHashDB(fabdir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func (m *Main) driverless(ctx context.Context) error {
 	ctx = WithForce(ctx, m.Force)
 	ctx = WithDryRun(ctx, m.DryRun)
 
-	db, err := OpenHashDB(ctx, m.Fabdir)
+	db, err := OpenHashDB(m.Fabdir)
 	if err != nil {
 		return errors.Wrap(err, "opening hash db")
 	}
@@ -146,12 +146,12 @@ var bolRegex = regexp.MustCompile("^")
 
 // OpenHashDB ensures the given directory exists and opens (or creates) the hash DB there.
 // Callers must make sure to call Close on the returned DB when finished with it.
-func OpenHashDB(ctx context.Context, dir string) (*sqlite.DB, error) {
+func OpenHashDB(dir string) (*sqlite.DB, error) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, errors.Wrapf(err, "creating directory %s", dir)
 	}
 	dbfile := filepath.Join(dir, "hash.db")
-	db, err := sqlite.Open(ctx, dbfile, sqlite.Keep(30*24*time.Hour)) // keep db entries for 30 days
+	db, err := sqlite.Open(dbfile, sqlite.Keep(30*24*time.Hour)) // keep db entries for 30 days
 	return db, errors.Wrapf(err, "opening file %s", dbfile)
 }
 

--- a/sqlite/db.go
+++ b/sqlite/db.go
@@ -28,7 +28,7 @@ var migrations embed.FS
 // Open opens the given file and returns it as a *DB.
 // The file is created if it doesn't already exist.
 // Callers should call Close when finished operating on the database.
-func Open(ctx context.Context, path string, opts ...Option) (*DB, error) {
+func Open(path string, opts ...Option) (*DB, error) {
 	db, err := sql.Open("sqlite3", path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "opening sqlite db %s", path)

--- a/sqlite/db_test.go
+++ b/sqlite/db_test.go
@@ -20,7 +20,7 @@ func TestDB(t *testing.T) {
 
 	ctx := context.Background()
 
-	db, err := Open(ctx, tmpfile.Name())
+	db, err := Open(tmpfile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestDBKeep(t *testing.T) {
 		clk = clock.NewMock()
 	)
 
-	db, err := Open(ctx, tmpfile.Name(), Keep(time.Hour), WithClock(clk), UpdateOnAccess(false))
+	db, err := Open(tmpfile.Name(), Keep(time.Hour), WithClock(clk), UpdateOnAccess(false))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/types.go
+++ b/types.go
@@ -12,7 +12,7 @@ import (
 
 var targetMethods = make(map[string]reflect.Method)
 
-// nullTarget is here so we can get reflection info about Target
+// nullTarget is here so we can get reflection info about Target.
 type nullTarget struct{}
 
 var _ Target = nullTarget{}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -118,7 +118,7 @@ func TestYAML(t *testing.T) {
 
 	t.Run("Y", func(t *testing.T) {
 		gotY, gotYDoc := con.RegistryTarget("Y")
-		wantY := Clean("file1", "file2")
+		wantY := &Clean{Files: []string{"file1", "file2"}}
 		const wantYDoc = "Y cleans."
 		if !reflect.DeepEqual(gotY, wantY) {
 			t.Errorf("mismatch for Y; got:\n%s\nwant:\n%s", spew.Sdump(gotY), spew.Sdump(wantY))


### PR DESCRIPTION
This PR adds the "autoclean" feature: output files of `Files` targets can be added to a registry for use by `Clean`.

It incidentally changes `Clean` from a function to a type. It also configures a few new linters and fixes some things they found.